### PR TITLE
eliminar firestore de firebase.json

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -15,9 +15,5 @@
   },
   "database": {
     "rules": "database.rules.json"
-  },
-  "firestore": {
-    "rules": "firestore.rules",
-    "indexes": "firestore.indexes.json"
   }
 }


### PR DESCRIPTION
No se hizo deploy debido a que en el archivo firebase,json aun se estaba nombrando a firestore.